### PR TITLE
fix: [sc-257503] [API-connect] Variables columns renaming feature is broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Version 1.2.5](https://github.com/dataiku/dss-plugin-api-connect/releases/tag/v1.2.5) - Bugfix release - 2025-02-28
+
+- Fix issue with variables columns renaming
+
 ## [Version 1.2.4](https://github.com/dataiku/dss-plugin-api-connect/releases/tag/v1.2.4) - Feature and bugfix release - 2025-02-18
 
 - Fix xml decoding for content type application/rss+xml

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "api-connect",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "meta": {
         "label": "API Connect",
         "description": "Retrieve data from any REST API",

--- a/python-lib/dku_constants.py
+++ b/python-lib/dku_constants.py
@@ -2,6 +2,6 @@ class DKUConstants(object):
     API_RESPONSE_KEY = "api_response"
     FORBIDDEN_KEYS = ["token", "password", "api_key_value", "secure_token"]
     FORM_DATA_BODY_FORMAT = "FORM_DATA"
-    PLUGIN_VERSION = "1.2.4"
+    PLUGIN_VERSION = "1.2.5-beta.1"
     RAW_BODY_FORMAT = "RAW"
     REPONSE_ERROR_KEY = "dku_error"

--- a/python-lib/dku_utils.py
+++ b/python-lib/dku_utils.py
@@ -10,6 +10,10 @@ logger = SafeLogger("api-connect plugin utils")
 
 
 def get_dku_key_values(endpoint_query_string):
+    return {key_value.get("from"): key_value.get("to") for key_value in endpoint_query_string if key_value.get("from")}
+
+
+def get_dku_duplicated_key_values(endpoint_query_string):
     result = defaultdict(list)
     for kv in endpoint_query_string:
         if kv.get('from') and kv.get('to'):

--- a/python-lib/rest_api_client.py
+++ b/python-lib/rest_api_client.py
@@ -4,7 +4,7 @@ import copy
 from pagination import Pagination
 from safe_logger import SafeLogger
 from loop_detector import LoopDetector
-from dku_utils import get_dku_key_values, template_dict, format_template, is_reponse_xml, xml_to_json
+from dku_utils import get_dku_key_values, get_dku_duplicated_key_values, template_dict, format_template, is_reponse_xml, xml_to_json
 from dku_constants import DKUConstants
 from rest_api_auth import get_auth
 
@@ -196,7 +196,7 @@ class RestAPIClient(object):
 
     @staticmethod
     def get_params(endpoint_query_string, keywords, allow_list=False):
-        templated_query_string = get_dku_key_values(endpoint_query_string)
+        templated_query_string = get_dku_duplicated_key_values(endpoint_query_string)
         ret = {}
         for key in templated_query_string:
             ret.update({key: format_template(templated_query_string.get(key, ""), allow_list=allow_list, **keywords) or ""})

--- a/tests/python/integration/test_scenario.py
+++ b/tests/python/integration/test_scenario.py
@@ -53,3 +53,7 @@ def test_run_api_connect_check_sc_163656_error_column_always_in_schema(user_dss_
 
 def test_run_api_connect_xml_handling(user_dss_clients):
     dss_scenario.run(user_dss_clients, project_key=TEST_PROJECT_KEY, scenario_id="XML_HANDLING")
+
+
+def test_run_api_connect_parameters_renaming(user_dss_clients):
+    dss_scenario.run(user_dss_clients, project_key=TEST_PROJECT_KEY, scenario_id="COLUMNPARAMETERRENAMING")


### PR DESCRIPTION
Story details: https://app.shortcut.com/dataiku/story/257503